### PR TITLE
hide body scrollbar

### DIFF
--- a/newtab.html
+++ b/newtab.html
@@ -8,6 +8,7 @@
     color: #343434;
     padding: 0;
     margin: 0;
+    overflow: hidden;
   }
   #note-content {
     box-sizing: border-box;


### PR DESCRIPTION

![screenshot at dez 20 14-43-25](https://user-images.githubusercontent.com/19303435/34209875-2a0b8fc8-e594-11e7-9e81-19160d7149a2.png)

this simple overflow hidden on the body fixes the unnecessary body-scrollbar if the content doesn't reach 100vh and the double scrollbars if the content exceeds 100vh.

This misbehaviour of 100vh was maybe introduced with a new FF version because i can't see any scrollbars on your screens. 